### PR TITLE
パスワード再設定ページの実装

### DIFF
--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,10 +1,14 @@
-%h2 Forgot your password?
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .actions
-    = f.submit "Send me reset password instructions"
-= render "devise/shared/links"
+= render "layouts/header"
+.registration_wrapper
+  .fields
+    %h2 Forgot your password?
+    = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      .field
+        .field__name
+          = f.label :email
+        .field__box
+          = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control"
+      .actions
+        = f.submit "Send me reset password instructions", class: "btn btn-primary"
+    = render "devise/shared/links"


### PR DESCRIPTION
## 概要

パスワード再設定ページのhamlを編集した。

## 実装内容

ユーザー登録、ログインページと同じレイアウトにするため、
共通するレイアウト部分に対して、同じクラス名を記述した。