### PR TITLE
Make:投稿詳細ページの実装(サーバーサイド)

### DIFF
--- a/app/assets/stylesheets/modules/posts/_show.scss
+++ b/app/assets/stylesheets/modules/posts/_show.scss
@@ -29,6 +29,14 @@
               text-align: center;
               line-height: 45px;
             }
+            .img {
+              border: solid thin rgb(200, 200, 200);
+              width: 40px;
+              height: 40px;
+              border-radius: 20px;
+              text-align: center;
+              line-height: 45px;
+            }
             .username {
               padding: 10px;
             }

--- a/app/assets/stylesheets/modules/posts/_show.scss
+++ b/app/assets/stylesheets/modules/posts/_show.scss
@@ -50,11 +50,16 @@
           width: 100%;
         }
       }
+      .description {
+        background: #fff;
+        padding: 20px;
+        border: solid thin rgb(200, 200, 200);
+      }
       .comments {
         border: solid thin rgb(200, 200, 200);
         border-top: none;
         background: #fff;
-        margin-bottom: 20px;
+        margin: 20px 0;
         padding-top: 20px;
         .heading {
           display: flex;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -19,7 +19,8 @@ class PostsController < ApplicationController
   end
 
   def show
-    @page = Wikipedia.find('ベネチア')
+    @post = Post.find(params[:id])
+    @wiki = Wikipedia.find(@post.name)
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,4 +2,6 @@ class Post < ApplicationRecord
   mount_uploader :image, ImageUploader
   validates :name, presence: :true
   validates :image, presence: :true
+
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  mount_uploader :image, ImageUploader
   validates :name, presence: true
+
+  has_many :posts
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-
+  process resize_to_fit: [800, 800]
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -3,13 +3,18 @@
     .main-contents
       .card
         .card-body
-          %h5.card-title#name ベネチア
+          %h5.card-title#name
+            = @post.name
           .profile
-            .image
-              %i.fas.fa-user-alt.fa-lg
-            .username username
+            - if @post.user.image.nil?
+              .image
+                %i.fas.fa-user-alt.fa-lg
+            - else
+              = image_tag @post.user.image.to_s, class: "img"
+            .username
+              = @post.user.name
       .post
-        = image_tag('second-slide.jpg')
+        = image_tag @post.image.to_s
       .comments
         .heading
           %i.fas.fa-comment
@@ -21,8 +26,8 @@
           %i.fab.fa-wikipedia-w.fa-2x
           Wikipedia情報
         .info
-          = @page.summary
-          = link_to "詳しい説明はこちら", @page.fullurl, target: :_blank
+          = @wiki.summary
+          = link_to "詳しい説明はこちら", @wiki.fullurl, target: :_blank
       .googleMap
         #map_container
           #map_canvas

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -15,6 +15,8 @@
               = @post.user.name
       .post
         = image_tag @post.image.to_s
+      .description
+        = @post.description
       .comments
         .heading
           %i.fas.fa-comment

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -26,4 +26,16 @@ describe PostsController, type: :controller  do
       expect(response).to redirect_to posts_path
     end
   end
+
+  describe 'GET #show' do
+    before do
+      login_user user
+    end
+
+    it "assigns the requested post to @post" do
+      post = create(:post, user_id: user.id)
+      get :show, params: { id: post }
+      expect(assigns(:post)).to eq post
+    end
+  end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -16,13 +16,13 @@ describe PostsController, type: :controller  do
     end
 
     it "saves the new post in the database" do
-      expect do
-        post :create, params: { post: attributes_for(:post) }
-      end.to change(Post, :count).by(1)
+      expect {
+        post :create, params: { user_id: user.id, post: attributes_for(:post) }
+      }.to change(Post, :count).by(1)
     end
 
     it "redirects to posts#index" do
-      post :create, params: { post: attributes_for(:post) }
+      post :create, params: { user_id: user.id, post: attributes_for(:post) }
       expect(response).to redirect_to posts_path
     end
   end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -37,5 +37,11 @@ describe PostsController, type: :controller  do
       get :show, params: { id: post }
       expect(assigns(:post)).to eq post
     end
+
+    it "renders the :show template" do
+      post = create(:post, user_id: user.id)
+      get :show, params: { id: post }
+      expect(response).to render_template :show
+    end
   end
 end


### PR DESCRIPTION
## チェックポイント

## 概要
　投稿された景色の詳細情報をDBから取り出し、表示できるよう実装

## 実装内容
  @postを定義し、ビューで投稿のタイトル、画像、説明文、投稿者名が表示されるよう実装
  @wikiを定義し、投稿された場所のwikipedia情報が表示されるように実装

## 動作確認項目
 - showアクション内で定義されている@postに作成されたpostと一致している
 - showアクションが動いた時に、期待したビューに遷移する