### PR TITLE
投稿一覧ページの実装(サーバーサイド)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,4 @@ gem 'mini_magick'
 gem "rake"
 gem 'devise'
 gem 'wikipedia-client'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     kgio (2.11.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -349,6 +361,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/stylesheets/mixin/_post.scss
+++ b/app/assets/stylesheets/mixin/_post.scss
@@ -1,8 +1,6 @@
 @mixin post() {
   border: solid 1px #CED4DA;
-  border-radius: 5px;
   cursor: pointer;
   width: 300px;
   height: 250px;
-  background-color: #fff;
 }

--- a/app/assets/stylesheets/modules/posts/_index.scss
+++ b/app/assets/stylesheets/modules/posts/_index.scss
@@ -7,6 +7,7 @@
   padding-bottom: 10vh;
   .contents {
     .posts {
+      @include clearfix();
       width: 1000px;
       padding-top: 50px;
       margin: 0 auto;

--- a/app/assets/stylesheets/modules/posts/_index.scss
+++ b/app/assets/stylesheets/modules/posts/_index.scss
@@ -3,23 +3,18 @@
 @import "mixin/post";
 
 .posts-index-wrapper{
-  @include clearfix();
   background: $background-color;
   padding-bottom: 10vh;
   .contents {
-    @include clearfix();
-    float: left;
     .posts {
       width: 1000px;
       padding-top: 50px;
+      margin: 0 auto;
       .post {
         @include post();
         float: left;
         margin: 10px;
       }
     }
-  }
-  .sideContent {
-    float: left;
   }
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
     path   'w/api.php'
   }
   def index
-    @posts = Post.includes(:user).order("created_at DESC")
+    @posts = Post.includes(:user).page(params[:page]).per(9).order("created_at DESC")
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,7 @@ class PostsController < ApplicationController
     path   'w/api.php'
   }
   def index
+    @posts = Post.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link'
+- else
+  %li.page-item
+    = link_to page, url, remote: remote, rel: page.rel, class: 'page-link'

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,12 @@
+= paginator.render do
+  %nav
+    %ul.pagination.justify-content-center
+      = first_page_tag unless current_page.first?
+      = prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          = page_tag page
+        - elsif !page.was_truncated?
+          = gap_tag
+      = next_page_tag unless current_page.last?
+      = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -1,15 +1,7 @@
 .posts-index-wrapper.clearfix
   .contents
-    .posts.clearfix
-      .post
-      .post
-      .post
-      .post
-      .post
-      .post
-      .post
-      .post
-      .post
+    .posts
+      - @posts.each do |post|
+        = link_to "/posts/#{post.id}" do
+          = image_tag post.image.to_s, class: "post"
     .pagination
-  .sideContent
-    = render 'ranking'

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -1,7 +1,7 @@
-.posts-index-wrapper.clearfix
+.posts-index-wrapper
   .contents
-    .posts
+    .posts.clearfix
       - @posts.each do |post|
         = link_to "/posts/#{post.id}" do
           = image_tag post.image.to_s, class: "post"
-    .pagination
+    = paginate @posts

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -2,6 +2,19 @@ require 'rails_helper'
 
 describe PostsController, type: :controller  do
   let(:user) { create(:user) }
+  let(:posts) { create_list(:post, 3, user_id: user.id) }
+
+  describe 'GET #index' do
+    it "assigns the requested posts to @posts" do
+        get :index
+        expect(assigns(:posts)).to eq posts
+    end
+
+    it "renders the :index template" do
+      get :index
+      expect(response).to render_template :index
+    end
+  end
 
   describe 'GET #new' do
     it "renders the :new template" do

--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
 
   factory :post do
-    name                  {"testname"}
+    name                  {Faker::Name.name}
     image                 { Rack::Test::UploadedFile.new(File.join(Rails.root, 'public/uploads/post/image/2/glass-3114335_640.jpg')) }
-    description           {"綺麗な風景です"}
+    description           {Faker::Lorem.sentence(4)}
   end
 
 end


### PR DESCRIPTION
## 概要

投稿一覧ページのサーバーサイドを実装

## UI変更点

右サイドバーのランキング一覧を削除し、
投稿一覧のみとした。

## 実装内容

・投稿された画像の一覧表示
・ページネーション
・単体テスト


## 動作確認項目
・@postsと作成されたpostsが一致することを確認
・posts#indexが動くと、indexページへ遷移することを確認