### PR TITLE
ユーザー編集ページの実装（サーバーサイド）

### DIFF
--- a/app/assets/stylesheets/modules/posts/_show.scss
+++ b/app/assets/stylesheets/modules/posts/_show.scss
@@ -87,7 +87,8 @@
           }
         }
         &__content {
-          height: 60vh;
+          min-height: 0vh;
+          max-height: 60vh;
           overflow: auto;
         }
       }

--- a/app/assets/stylesheets/modules/users/_edit.scss
+++ b/app/assets/stylesheets/modules/users/_edit.scss
@@ -34,6 +34,13 @@
         height: 100px;
         background-position: center;
         background-color: #fff;
+        position: relative;
+        img {
+          width: 100px;
+          height: 100px;
+          position: absolute;
+          border-radius: 5px;
+        }
       }
     }
     .actions {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,4 +8,16 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @posts = @user.posts.page(params[:page]).per(6)
   end
+
+  def update
+    user = User.find(params[:id])
+      user.update(user_params)
+      redirect_to user_path(params[:id])
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :image)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,21 +1,24 @@
 class UsersController < ApplicationController
 
+  before_action :set_user, only: [:edit, :show, :update]
+
   def edit
-    @user = User.find(params[:id])
   end
 
   def show
-    @user = User.find(params[:id])
     @posts = @user.posts.page(params[:page]).per(6)
   end
 
   def update
-    user = User.find(params[:id])
-      user.update(user_params)
+      @user.update(user_params)
       redirect_to user_path(params[:id])
   end
 
   private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
 
   def user_params
     params.require(:user).permit(:name, :image)

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -2,6 +2,6 @@
   .contents
     .posts.clearfix
       - @posts.each do |post|
-        = link_to "/posts/#{post.id}" do
+        = link_to "/posts/#{post.id}", data: {"turbolinks"=>false} do
           = image_tag post.image.to_s, class: "post"
     = paginate @posts

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -18,3 +18,4 @@
           = f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control"
       .actions
         = f.submit "Update", class: "btn btn-primary"
+      = link_to "Back", user_path(@user), class: "btn btn-primary"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -9,6 +9,8 @@
           = f.file_field :image, style:"display:none;", id: "file"
           .preview{ onClick: "$('#file').click()" }
             %i.fas.fa-plus
+            - if @user.image.present?
+              = image_tag @user.image.to_s
       .field
         .field__name
           = f.label :name

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -10,9 +10,10 @@
       .profile__info
         .profile__info--username
           = @user.name
-        %button.btn.btn-secondary{:type => "button"} プロフィールを編集
+        = link_to edit_user_path(@user), data: {"turbolinks"=>false} do
+          %button.btn.btn-secondary{:type => "button"} プロフィールを編集
     .posts
       - @posts.each do |post|
-        = link_to post_path(post) do
+        = link_to post_path(post), data: {"turbolinks"=>false} do
           = image_tag post.image.url, class: "post"
     = paginate @posts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :comments, only:[:create]
   end
 
-  resources :users, only:[:edit, :show]
+  resources :users, only:[:edit, :update, :show]
 
   root "toppages#index"
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -22,4 +22,34 @@ RSpec.describe UsersController, type: :controller do
       expect(response).to render_template :show
     end
   end
+
+  describe 'GET #edit' do
+    it "assigns the requested user to @user" do
+      get :edit, params: { id: user.id }
+      expect(assigns(:user)).to eq user
+    end
+
+    it "renders the :edit template" do
+      get :edit, params: { id: user.id }
+      expect(response).to render_template :edit
+    end
+  end
+
+  describe 'PATCH #update' do
+    it "locates the requersted @user" do
+      patch :update, params: { user: attributes_for(:user), id: user.id }
+      expect(assigns(:user)).to eq user
+    end
+
+    it "changes @user's attributes" do
+      patch :update, params: {id: user.id, user: attributes_for(:user, name: 'abc')}
+      user.reload
+      expect(user.name).to eq("abc")
+    end
+
+    it "redirects to user_path" do
+      patch :update, params: { user: attributes_for(:user), id: user.id }
+      expect(response).to redirect_to user_path(user)
+    end
+  end
 end


### PR DESCRIPTION
## 概要
ユーザーの編集ページで、
ユーザーの名前や画像を変更できるよう実装した。


## 動作確認項目

 -  リクエストした際に想定したuserが呼び出されること。
 -  userの属性を変更し更新できること。
 -  更新後はユーザマイページに遷移すること。