### PR TITLE
Add: 環境変数の設定を追加

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,11 +16,30 @@ set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5
 
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  GOOGLE_STORAGE_ACCESS_KEY_ID: ENV["GOOGLE_STORAGE_ACCESS_KEY_ID"],
+  GOOGLE_STORAGE_SECRET_ACCESS_KEY: ENV["GOOGLE_STORAGE_SECRET_ACCESS_KEY"]
+}
+
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do
     invoke 'unicorn:restart'
   end
+
+  desc 'upload master.key'
+  task :upload do
+    on roles(:app) do |host|
+      if test "[ ! -d #{shared_path}/config ]"
+        execute "mkdir -p #{shared_path}/config"
+      end
+      upload!('config/master.key', "#{shared_path}/config/master.key")
+    end
+  end
+  before :starting, 'deploy:upload'
+  after :finishing, 'deploy:cleanup'
 end
 
 # Default branch is :master


### PR DESCRIPTION
## 概要


環境変数をcapistranoでの自動デプロイで利用するため、
Config/deploy.rbで明示的に環境変数を指定
