### PR TITLE
投稿編集ページの実装（サーバーサイド）

### DIFF
--- a/app/assets/stylesheets/modules/posts/_new_and_edit.scss
+++ b/app/assets/stylesheets/modules/posts/_new_and_edit.scss
@@ -40,6 +40,12 @@
             display: block;
             color: rgb(190, 190, 190);
           }
+          #defaultImage {
+            width: 300px;
+            height: 250px;
+            position: absolute;
+            border-radius: 5px;
+          }
         }
       }
       .action {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,6 +4,9 @@ class PostsController < ApplicationController
     domain 'ja.wikipedia.org'
     path   'w/api.php'
   }
+
+  before_action :set_post, only: [:edit, :update, :show]
+
   def index
     @posts = Post.includes(:user).page(params[:page]).per(9).order("created_at DESC")
   end
@@ -19,13 +22,21 @@ class PostsController < ApplicationController
   def edit
   end
 
+  def update
+    @post.update(post_params)
+    redirect_to post_path(params[:id])
+  end
+
   def show
-    @post = Post.find(params[:id])
     @wiki = Wikipedia.find(@post.name)
     @comments = @post.comments.includes(:user)
   end
 
   private
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
 
   def post_params
     params.require(:post).permit(:name, :image, :description).merge(user_id: current_user.id)

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -3,7 +3,7 @@
     .card-header
       投稿編集
     .card-body
-      = form_with url: posts_path do |f|
+      = form_with(model: @post, local: true) do |f|
         .field
           %label 場所の名前
           %span 必須
@@ -15,10 +15,12 @@
           = f.file_field :image, style:"display:none;", id: "file"
           .preview{ onClick: "$('#file').click()"}
             %i.far.fa-image.fa-5x
+            - if @post.image.present?
+              = image_tag @post.image.to_s, id: "defaultImage"
         .field
           %label 説明文
           %span.arbitrary 任意
-          = f.text_area :name, class: "form-control"
+          = f.text_area :description, class: "form-control"
 
         .action
           = f.submit "変更する", class: "btn btn-primary"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  resources :posts, only:[:index, :new, :create, :edit, :show] do
+  resources :posts, only:[:index, :new, :create, :edit, :update, :show] do
     resources :comments, only:[:create]
   end
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -72,6 +72,27 @@ describe PostsController, type: :controller  do
     end
   end
 
+  describe 'PATCH #update' do
+    let(:post) { create(:post, user_id: user.id)}
 
+    before do
+      login_user user
+    end
 
+    it "locates the requersted @post" do
+      patch :update, params: { post: attributes_for(:post), id: post.id }
+      expect(assigns(:post)).to eq post
+    end
+
+    it "changes @post's attributes" do
+      patch :update, params: {id: post.id, post: attributes_for(:post, name: 'abcde')}
+      post.reload
+      expect(post.name).to eq("abcde")
+    end
+
+    it "redirects to post_path" do
+      patch :update, params: { post: attributes_for(:post), id: post.id }
+      expect(response).to redirect_to post_path(post)
+    end
+  end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -57,4 +57,21 @@ describe PostsController, type: :controller  do
       expect(response).to render_template :show
     end
   end
+
+  describe 'GET #edit' do
+    let(:post) { create(:post, user_id: user.id)}
+
+    it "assigns the requested post to @post" do
+      get :edit, params: { id: post.id }
+      expect(assigns(:post)).to eq post
+    end
+
+    it "renders the :edit template" do
+      get :edit, params: { id: post.id }
+      expect(response).to render_template :edit
+    end
+  end
+
+
+
 end


### PR DESCRIPTION
## 概要

記事投稿編集ページのサーバーサイドを実装

## 実装内容

DBから呼び出したレコードを@postとしてviewに表示し、
編集できるように実装した。


## 動作確認項目

posts#edit
・@postが期待した値となっていること
・posts#editでeditのビューに遷移すること

posts#update
・posts#updateが動いた時、@postに期待した値が代入されている。
・postのデータを変更した際に、DBに変更が反映されている。
・posts#updateが動いた後、post_pathへリダイレクトする。
