### PR TITLE
Upgrade: gem yard のバージョンをアップグレード

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,7 @@ GEM
     wikipedia-client (1.10.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.19)
+    yard (0.9.20)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## 概要

以前のバージョンでは、脆弱性が発見されたため、バージョンをアップグレードした

