### PR TITLE
Add: bundlerのversionを変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.4.1-node-browsers
+      - image: circleci/ruby:2.5.1-node-browsers
         environment:
 
           BUNDLER_VERSION: 2.0.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,9 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/ruby:2.4.1-node-browsers
+        environment:
 
+          BUNDLER_VERSION: 2.0.1
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -18,6 +20,15 @@ jobs:
 
     steps:
       - checkout
+
+      - run:
+          name: setup bundler
+          command: |
+            sudo gem update --system
+            sudo gem uninstall bundler
+            sudo rm /usr/local/bin/bundle
+            sudo rm /usr/local/bin/bundler
+            sudo gem install bundler
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
## 概要

bundler 2.X 系で作成された Gemfile.lock ファイルが 、
CircleCI 上で bundle install できなかったため、対応できるようにした。