### PR TITLE
Change: turbolinkの設定変更

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -6,7 +6,7 @@
     %ul.navbar-nav.ml-auto
       - if user_signed_in?
         %li.nav-item
-          = link_to "投稿する", new_post_path, class: "btn post", role: "button"
+          = link_to "投稿する", new_post_path, class: "btn post", role: "button", data: {"turbolinks"=>false}
         %li.nav-item
           = link_to "全投稿一覧", posts_path, class: "nav-link"
         %li.nav-item

--- a/app/views/posts/_ranking.html.haml
+++ b/app/views/posts/_ranking.html.haml
@@ -11,6 +11,6 @@
       - else
         %span.fas.fa-star.fa-stack-2x
         %span.fa.fa-stack-1x= i + 1
-    =link_to post_path(post) do
+    =link_to post_path(post), data: {"turbolinks"=>false} do
       .post
         = image_tag post.image.to_s

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -18,7 +18,7 @@
       .description
         - if current_user == @post.user
           .edit
-            = link_to "編集する", edit_post_path, class: "btn btn-primary", role: "button"
+            = link_to "編集する", edit_post_path, class: "btn btn-primary", role: "button", data: {"turbolinks"=>false}
         .favorite
           = render partial: 'favorites/favorite', locals: {post: @post}
         = @post.description


### PR DESCRIPTION
## 概要

ページ遷移先でjsを機能させるため、
turbolinkを無効にする記述を追加した。

追加部分は、以下のlink_toタグである。
- 投稿詳細ページの「編集する」ボタン
- 投稿詳細ページのランキングに表示された画像
- ヘッダーの「投稿する」ボタン